### PR TITLE
Fix the gradient in rasterize_backward_sum_kernel

### DIFF
--- a/gsplat/cuda/csrc/backward.cu
+++ b/gsplat/cuda/csrc/backward.cu
@@ -830,7 +830,7 @@ __global__ void rasterize_backward_sum_kernel(
 
                 const float v_sigma = -opac * vis * v_alpha;
                 v_conic_local = {0.5f * v_sigma * delta.x * delta.x, 
-                                        0.5f * v_sigma * delta.x * delta.y, 
+                                        v_sigma * delta.x * delta.y, 
                                         0.5f * v_sigma * delta.y * delta.y};
                 v_xy_local = {v_sigma * (conic.x * delta.x + conic.y * delta.y), 
                                     v_sigma * (conic.y * delta.x + conic.z * delta.y)};


### PR DESCRIPTION
`sigma = 0.5f * (conic.x * delta.x * delta.x + conic.z * delta.y * delta.y) + conic.y * delta.x * delta.y;`

\frac{d sigma}{d conic.y} = delta.x * delta.y