### PR TITLE
fix: prevent out-of-bounds GPU memory write in get_tile_bin_edges

### DIFF
--- a/gsplat/cuda/csrc/bindings.cu
+++ b/gsplat/cuda/csrc/bindings.cu
@@ -313,11 +313,12 @@ std::tuple<torch::Tensor, torch::Tensor> map_gaussian_to_intersects_tensor(
 }
 
 torch::Tensor get_tile_bin_edges_tensor(
-    int num_intersects, const torch::Tensor &isect_ids_sorted
+    int num_intersects, const torch::Tensor &isect_ids_sorted, int num_tiles
 ) {
     CHECK_INPUT(isect_ids_sorted);
+    int alloc_size = std::max(num_intersects, num_tiles);
     torch::Tensor tile_bins = torch::zeros(
-        {num_intersects, 2}, isect_ids_sorted.options().dtype(torch::kInt32)
+        {alloc_size, 2}, isect_ids_sorted.options().dtype(torch::kInt32)
     );
     get_tile_bin_edges<<<
         (num_intersects + N_THREADS - 1) / N_THREADS,

--- a/gsplat/cuda/csrc/bindings.h
+++ b/gsplat/cuda/csrc/bindings.h
@@ -100,7 +100,8 @@ std::tuple<torch::Tensor, torch::Tensor> map_gaussian_to_intersects_tensor(
 
 torch::Tensor get_tile_bin_edges_tensor(
     int num_intersects,
-    const torch::Tensor &isect_ids_sorted
+    const torch::Tensor &isect_ids_sorted,
+    int num_tiles
 );
 
 std::tuple<

--- a/gsplat/utils.py
+++ b/gsplat/utils.py
@@ -51,7 +51,8 @@ def map_gaussian_to_intersects(
 
 
 def get_tile_bin_edges(
-    num_intersects: int, isect_ids_sorted: Int[Tensor, "num_intersects 1"]
+    num_intersects: int, isect_ids_sorted: Int[Tensor, "num_intersects 1"],
+    num_tiles: int = 0,
 ) -> Int[Tensor, "num_intersects 2"]:
     """Map sorted intersection IDs to tile bins which give the range of unique gaussian IDs belonging to each tile.
 
@@ -65,13 +66,14 @@ def get_tile_bin_edges(
     Args:
         num_intersects (int): total number of gaussian intersects.
         isect_ids_sorted (Tensor): sorted unique IDs for each gaussian in the form (tile | depth id).
+        num_tiles (int): total number of tiles. Used to ensure the output is large enough.
 
     Returns:
         A Tensor:
 
         - **tile_bins** (Tensor): range of gaussians IDs hit per tile.
     """
-    return _C.get_tile_bin_edges(num_intersects, isect_ids_sorted.contiguous())
+    return _C.get_tile_bin_edges(num_intersects, isect_ids_sorted.contiguous(), num_tiles)
 
 
 def compute_cov2d_bounds(
@@ -163,5 +165,6 @@ def bin_and_sort_gaussians(
     )
     isect_ids_sorted, sorted_indices = torch.sort(isect_ids)
     gaussian_ids_sorted = torch.gather(gaussian_ids, 0, sorted_indices)
-    tile_bins = get_tile_bin_edges(num_intersects, isect_ids_sorted)
+    num_tiles = tile_bounds[0] * tile_bounds[1]
+    tile_bins = get_tile_bin_edges(num_intersects, isect_ids_sorted, num_tiles)
     return isect_ids, gaussian_ids, isect_ids_sorted, gaussian_ids_sorted, tile_bins

--- a/tests/test_tile_bin_edges_oob.py
+++ b/tests/test_tile_bin_edges_oob.py
@@ -1,0 +1,52 @@
+"""
+Test that get_tile_bin_edges correctly handles the case where
+num_tiles > num_intersects.
+"""
+
+import pytest
+import torch
+
+device = torch.device("cuda:0")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No CUDA device")
+def test_tile_bins_oob_when_num_tiles_exceeds_num_intersects():
+    from gsplat.utils import get_tile_bin_edges
+
+    # Suppose we have a 512x512 image with 16x16 tiles => 32x32 = 1024 tiles.
+    # But only 3 gaussians, each hitting exactly 1 tile, so num_intersects = 3.
+    # the kernel writes to tile_bins[tile_idx] where tile_idx can be up to 1023
+
+    num_tiles = 1024  # 32 x 32 tile grid
+    num_intersects = 3
+
+    # Craft isect_ids_sorted: each entry is (tile_id << 32 | depth_id).
+    # Place intersections in tiles 0, 500, and 1023 (the last tile).
+    tile_ids = torch.tensor([0, 500, 1023], dtype=torch.int64, device=device)
+    depth_ids = torch.tensor([0, 0, 0], dtype=torch.int64, device=device)
+    isect_ids_sorted = (tile_ids << 32) | depth_ids
+
+    tile_bins = get_tile_bin_edges(num_intersects, isect_ids_sorted, num_tiles)
+
+    # Verify the output is large enough to index by any tile.
+    assert tile_bins.shape[0] >= num_tiles, (
+        f"tile_bins has {tile_bins.shape[0]} rows but we need at least {num_tiles} "
+        f"to safely index by tile_id"
+    )
+
+    # Verify correctness of the bin edges for the tiles that have intersections.
+    # tile 0: intersects [0, 1)
+    assert tile_bins[0, 0].item() == 0
+    assert tile_bins[0, 1].item() == 1
+
+    # tile 500: intersects [1, 2)
+    assert tile_bins[500, 0].item() == 1
+    assert tile_bins[500, 1].item() == 2
+
+    # tile 1023: intersects [2, 3)
+    assert tile_bins[1023, 0].item() == 2
+    assert tile_bins[1023, 1].item() == 3
+
+    # Tiles with no intersections should have [0, 0] (empty range).
+    assert tile_bins[1, 0].item() == 0 and tile_bins[1, 1].item() == 0
+    assert tile_bins[999, 0].item() == 0 and tile_bins[999, 1].item() == 0


### PR DESCRIPTION
## Description
This PR fixes a critical bug where the `get_tile_bin_edges` CUDA kernel could perform out-of-bounds memory writes, leading to silent memory corruption or `RuntimeError: CUDA error: an illegal memory access was encountered`. 

## Root Cause
In the `get_tile_bin_edges` kernel, the output tensor `tile_bins` is indexed using the tile ID (`cur_tile_idx` or `prev_tile_idx`), meaning the maximum index written to can be up to `num_tiles - 1`. 

However, `tile_bins` was previously allocated with a shape of `[num_intersects, 2]`. If a user renders a scene with very few Gaussians on a high-resolution grid, the number of tiles can easily exceed the number of intersections (`num_tiles > num_intersects`), causing the kernel to write past the allocated tensor length.

## Example Scenario
If rendering at 512×512 with 16×16 tiles, `num_tiles` is 1024. If there are only 3 Gaussians that hit exactly 1 tile each, `num_intersects` is 3. The `tile_bins` tensor would be allocated with size 3, but the tile IDs written to could still be up to 1023, causing an out-of-bounds GPU write.

This scenario commonly occurs:
- **During early training** when Gaussians are sparse and cover few tiles
- **At high resolutions** (many tiles) with few Gaussians
- **With small/distant Gaussians** that have minimal screen coverage

## Solution
- Plumbed `num_tiles` down from Python's `bin_and_sort_gaussians` into the C++ `get_tile_bin_edges` binding
- Allocated the `tile_bins` tensor using size `std::max(num_intersects, num_tiles)` instead of just `num_intersects` to guarantee it can always safely index tile IDs
- Added a pytest regression test (`tests/test_tile_bin_edges_oob.py`) to verify behavior when `num_tiles > num_intersects`

## Changes
- `gsplat/cuda/csrc/bindings.h`: Added `num_tiles` parameter to function signature
- `gsplat/cuda/csrc/bindings.cu`: Changed allocation from `num_intersects` to `max(num_intersects, num_tiles)`
- `gsplat/utils.py`: Updated Python API to accept and pass `num_tiles` parameter
- `tests/test_tile_bin_edges_oob.py`: New regression test that would fail on the original version

## Testing
The new test constructs a minimal scenario with `num_tiles = 1024` and `num_intersects = 3`, placing intersections at tile indices 0, 500, and 1023. On the original version, this would:
- Allocate `tile_bins[3, 2]`
- Attempt to write to `tile_bins[500]` and `tile_bins[1023]`
- Trigger CUDA illegal memory access or silent corruption

With the fix, `tile_bins` is allocated as `[1024, 2]`, safely accommodating all tile indices.

## 中文简述

该 PR 修复了 `get_tile_bin_edges` CUDA kernel 可能发生 **GPU 越界写入（out-of-bounds write）** 的问题。

问题原因是 `tile_bins` 张量原先按 `num_intersects` 分配，但 kernel 在写入时使用的是 **tile ID 作为索引**，最大可能达到 `num_tiles - 1`。当 **tile 数量大于 intersection 数量（num_tiles > num_intersects）** 时，就会写出已分配的内存范围，可能导致：

* `CUDA error: an illegal memory access was encountered`
* 或更隐蔽的 GPU 内存破坏（silent memory corruption）

这种情况在以下场景较常见：

* 训练初期 Gaussian 数量很少
* 分辨率较高（tile 数量很多）
* Gaussian 很小或距离较远，只覆盖极少 tile

修复方式：

* 将 `num_tiles` 从 Python 侧传递到 C++ binding
* 将 `tile_bins` 的分配大小从 `num_intersects` 改为
  `max(num_intersects, num_tiles)`，确保 tile ID 索引始终安全
* 新增 regression test，覆盖 `num_tiles > num_intersects` 的情况